### PR TITLE
feature: #5 | Add MDCExt.Entry class to hold values

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>org.zeplinko</groupId>
     <artifactId>slf4j-ext</artifactId>
-    <version>1.0.0</version>
+    <version>1.1.0</version>
 
     <properties>
         <maven.compiler.source>11</maven.compiler.source>

--- a/src/main/java/org/zeplinko/slf4j/ext/MDCExt.java
+++ b/src/main/java/org/zeplinko/slf4j/ext/MDCExt.java
@@ -17,7 +17,9 @@ package org.zeplinko.slf4j.ext;
 
 import org.slf4j.MDC;
 
+import java.util.HashSet;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 
 /**
@@ -30,6 +32,19 @@ public final class MDCExt {
 
     private MDCExt() {
         // Private constructor to prevent instantiation
+    }
+
+    /**
+     * Creates an MDC entry with the specified key and value. Unlike
+     * {@link Map#entry(Object, Object)}, this method allows null values.
+     *
+     * @param key   the key (must not be null)
+     * @param value the value (maybe null)
+     * @return a new MDCExt.Entry instance
+     * @throws NullPointerException if key is null
+     */
+    public static MDCExt.Entry entry(String key, String value) {
+        return new MDCExt.Entry(key, value);
     }
 
     /**
@@ -53,10 +68,31 @@ public final class MDCExt {
      * @param entries varargs parameter of Map entries to add to the MDC
      * @return a closeable object that, when closed, will remove the added entries
      *         from the MDC
+     *
+     * @deprecated Instead use
+     *             {@link org.zeplinko.slf4j.ext.MDCExt#putCloseable(org.zeplinko.slf4j.ext.MDCExt.Entry...)}
      */
     @SafeVarargs
+    @Deprecated
     public static MDCExtCloseable putCloseable(Map.Entry<String, String>... entries) {
         return putCloseable(Map.ofEntries(entries));
+    }
+
+    /**
+     * Places multiple key-value pairs in the MDC from an array of MDCExt.Entry,
+     * returning a {@link MDCExtCloseable} that removes the entries when closed.
+     *
+     * @param entries varargs parameter of MDCExt.Entry to add to the MDC
+     * @return a closeable object that, when closed, will remove the added entries
+     *         from the MDC
+     */
+    public static MDCExtCloseable putCloseable(MDCExt.Entry... entries) {
+        HashSet<String> keys = new HashSet<>();
+        for (Entry entry : entries) {
+            MDC.put(entry.getKey(), entry.getValue());
+            keys.add(entry.getKey());
+        }
+        return new MDCExtCloseable(keys);
     }
 
     /**
@@ -103,6 +139,44 @@ public final class MDCExt {
         @Override
         public void close() {
             this.keys.forEach(MDC::remove);
+        }
+    }
+
+    /**
+     * Represents a key-value pair for MDC entries. Unlike {@link Map.Entry}, this
+     * class allows null values, which is necessary for MDC operations that need to
+     * set or remove context with null values.
+     */
+    public static final class Entry {
+
+        private static final String KEY_CANNOT_BE_NULL = "key cannot be null";
+
+        private final String key;
+
+        private final String value;
+
+        private Entry(String key, String value) {
+            Objects.requireNonNull(key, KEY_CANNOT_BE_NULL);
+            this.key = key;
+            this.value = value;
+        }
+
+        /**
+         * Returns the key of this entry.
+         *
+         * @return the key (never null)
+         */
+        public String getKey() {
+            return key;
+        }
+
+        /**
+         * Returns the value of this entry.
+         *
+         * @return the value (maybe null)
+         */
+        public String getValue() {
+            return value;
         }
     }
 }

--- a/src/test/java/org/zeplinko/slf4j/ext/test/MDCExtTest.java
+++ b/src/test/java/org/zeplinko/slf4j/ext/test/MDCExtTest.java
@@ -34,6 +34,10 @@ class MDCExtTest {
 
     public static final String VALUE_SESSION_ID = "abc123";
 
+    public static final String KEY_USER_REFERRER = "userReferrer";
+
+    public static final String VALUE_USER_REFERRER = null;
+
     @Test
     void testPutCloseableWithSingleEntry() {
         try (MDCExt.MDCExtCloseable closeable = MDCExt.putCloseable(KEY_USER_ID, VALUE_USER_ID)) {
@@ -55,6 +59,24 @@ class MDCExtTest {
         }
         assertNull(MDC.get(KEY_USER_ID));
         assertNull(MDC.get(KEY_SESSION_ID));
+    }
+
+    @Test
+    void testPutCloseableWithMultipleMDCExtEntries() {
+        try (
+                var closeable = MDCExt.putCloseable(
+                        MDCExt.entry(KEY_USER_ID, VALUE_USER_ID),
+                        MDCExt.entry(KEY_SESSION_ID, VALUE_SESSION_ID),
+                        MDCExt.entry(KEY_USER_REFERRER, VALUE_USER_REFERRER)
+                )
+        ) {
+            assertEquals(VALUE_USER_ID, MDC.get(KEY_USER_ID));
+            assertEquals(VALUE_SESSION_ID, MDC.get(KEY_SESSION_ID));
+            assertEquals(VALUE_USER_REFERRER, MDC.get(KEY_USER_REFERRER));
+        }
+        assertNull(MDC.get(KEY_USER_ID));
+        assertNull(MDC.get(KEY_SESSION_ID));
+        assertNull(MDC.get(KEY_USER_REFERRER));
     }
 
     @Test


### PR DESCRIPTION
closes #5 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduces a typed entry-based API for managing logging context with automatic scoped cleanup
  * Adds a factory method to create typed context entries (supports null values)

* **Deprecations**
  * Older map-based context management method deprecated; migrate to the new entry-based API

* **Chores**
  * Version bumped to 1.1.0

* **Tests**
  * Added test covering multiple-entry scoping and cleanup
<!-- end of auto-generated comment: release notes by coderabbit.ai -->